### PR TITLE
Fixes for AIX

### DIFF
--- a/kernext/ip_log.c
+++ b/kernext/ip_log.c
@@ -1,20 +1,20 @@
 /* IBM_PROLOG_BEGIN_TAG                                                   */
 /* This is an automatically generated prolog.                             */
 /*                                                                        */
-/* 53ipfl53H src/ipfl/kernext/ip_log.c 1.3                                */
+/* 53ipfl53H src/ipfl/kernext/ip_log.c 1.4                                */
 /*                                                                        */
 /* Licensed Materials - Property of IBM                                   */
 /*                                                                        */
 /* Restricted Materials of IBM                                            */
 /*                                                                        */
-/* COPYRIGHT International Business Machines Corp. 2006,2011              */
+/* COPYRIGHT International Business Machines Corp. 2006,2015              */
 /* All Rights Reserved                                                    */
 /*                                                                        */
 /* US Government Users Restricted Rights - Use, duplication or            */
 /* disclosure restricted by GSA ADP Schedule Contract with IBM Corp.      */
 /*                                                                        */
 /* IBM_PROLOG_END_TAG                                                     */
-static char sccsid[] = "@(#)05  1.3  src/ipfl/kernext/ip_log.c, ipflt, 53ipfl53H, 1205A_53ipfl53H 6/27/11 04:27:03";
+static char sccsid[] = "@(#)05  1.4  src/ipfl/kernext/ip_log.c, ipflt, 53ipfl53H, 1537A_53ipfl53H 3/28/15 05:51:06";
 /*
  * Copyright (C) 1997-2003 by Darren Reed.
  *
@@ -618,7 +618,7 @@ struct uio *uio;
 		MUTEX_EXIT(&ipl_mutex);
 		SPL_X(s);
 		locknest = lockl(&kernel_lock, LOCK_SHORT);
-		error = SLEEP(unit + iplh, "ipl sleep");
+		error = SLEEPWAKEONSIG(unit + iplh, "ipl sleep");
 		if (locknest != LOCK_NEST)
 			unlockl(&kernel_lock);
 #   endif /* __osf__ */

--- a/kernext/ip_nat.c
+++ b/kernext/ip_nat.c
@@ -1,20 +1,20 @@
 /* IBM_PROLOG_BEGIN_TAG                                                   */
 /* This is an automatically generated prolog.                             */
 /*                                                                        */
-/* 53ipfl53H src/ipfl/kernext/ip_nat.c 1.4                                */
+/* 53ipfl53H src/ipfl/kernext/ip_nat.c 1.5                                */
 /*                                                                        */
 /* Licensed Materials - Property of IBM                                   */
 /*                                                                        */
 /* Restricted Materials of IBM                                            */
 /*                                                                        */
-/* COPYRIGHT International Business Machines Corp. 2006,2008              */
+/* COPYRIGHT International Business Machines Corp. 2006,2016              */
 /* All Rights Reserved                                                    */
 /*                                                                        */
 /* US Government Users Restricted Rights - Use, duplication or            */
 /* disclosure restricted by GSA ADP Schedule Contract with IBM Corp.      */
 /*                                                                        */
 /* IBM_PROLOG_END_TAG                                                     */
-static char sccsid[] = "@(#)07  1.4  src/ipfl/kernext/ip_nat.c, ipflt, 53ipfl53H, 0834A_53ipfl53H 4/17/08 08:35:35";
+static char sccsid[] = "@(#)07  1.5  src/ipfl/kernext/ip_nat.c, ipflt, 53ipfl53H, 1617A_53ipfl53H 4/1/16 04:58:38";
 /*
  * Copyright (C) 1995-2003 by Darren Reed.
  *
@@ -3884,8 +3884,15 @@ u_32_t nflags;
 	if (csump != NULL) {
 		if (nat->nat_dir == NAT_OUTBOUND)
 			fix_outcksum(fin, csump, nat->nat_sumd[1]);
-		else
-			fix_incksum(fin, csump, nat->nat_sumd[1]);
+		else {
+#if defined(AIX)
+			if (!(fin->fin_m != NULL && fin->fin_m->m_flags & M_LARGESEND)) {
+#endif
+					fix_incksum(fin, csump, nat->nat_sumd[1]);
+#if defined(AIX)
+				}
+#endif
+			}
 	}
 #ifdef	IPFILTER_SYNC
 	ipfsync_update(SMC_NAT, fin, nat->nat_sync);

--- a/kernext/netinet/ip_compat.h
+++ b/kernext/netinet/ip_compat.h
@@ -1,20 +1,20 @@
 /* IBM_PROLOG_BEGIN_TAG                                                   */
 /* This is an automatically generated prolog.                             */
 /*                                                                        */
-/* 53ipfl53H src/ipfl/kernext/netinet/ip_compat.h 1.5                     */
+/* 53ipfl53H src/ipfl/kernext/netinet/ip_compat.h 1.6                     */
 /*                                                                        */
 /* Licensed Materials - Property of IBM                                   */
 /*                                                                        */
 /* Restricted Materials of IBM                                            */
 /*                                                                        */
-/* COPYRIGHT International Business Machines Corp. 2006,2009              */
+/* COPYRIGHT International Business Machines Corp. 2006,2015              */
 /* All Rights Reserved                                                    */
 /*                                                                        */
 /* US Government Users Restricted Rights - Use, duplication or            */
 /* disclosure restricted by GSA ADP Schedule Contract with IBM Corp.      */
 /*                                                                        */
 /* IBM_PROLOG_END_TAG                                                     */
-/* @(#)20  1.5  src/ipfl/kernext/netinet/ip_compat.h, ipflt, 53ipfl53H, 1016A_53ipfl53H 10/9/09 03:41:25 */
+/* @(#)20  1.6  src/ipfl/kernext/netinet/ip_compat.h, ipflt, 53ipfl53H, 1537A_53ipfl53H 3/28/15 05:50:03 */
 /*
  * Copyright (C) 1993-2001, 2003 by Darren Reed.
  *
@@ -1319,9 +1319,11 @@ extern void* getifp __P((char *, int));
 #endif /* __64BIT_KERNEL */
 #if 0
 #  define	SLEEP(id, n)	sleepx((id), PZERO+1, 0)
+#  define	SLEEPWAKEONSIG(id, n)	sleepx((id), PZERO+1, (SWAKEONSIG | PCATCH))
 #  define	WAKEUP(id,x)	wakeup(id)
 #else
 #  define       SLEEP(x, s)     sleepx(x##_aix, PZERO+1, 0)
+#  define	SLEEPWAKEONSIG(x, s)     sleepx(x##_aix, PZERO+1, (SWAKEONSIG | PCATCH))
 #  define       WAKEUP(x, y)    e_wakeup(x##_aix + y)
 #endif
 #  define	POLLWAKEUP(x)	;

--- a/usr/lib/methods/cfg_ipf.c
+++ b/usr/lib/methods/cfg_ipf.c
@@ -1,20 +1,20 @@
 /* IBM_PROLOG_BEGIN_TAG                                                   */
 /* This is an automatically generated prolog.                             */
 /*                                                                        */
-/* 53ipfl53H src/ipfl/usr/lib/methods/cfg_ipf.c 1.2                       */
+/* 53ipfl53H src/ipfl/usr/lib/methods/cfg_ipf.c 1.3                       */
 /*                                                                        */
 /* Licensed Materials - Property of IBM                                   */
 /*                                                                        */
 /* Restricted Materials of IBM                                            */
 /*                                                                        */
-/* (C) COPYRIGHT International Business Machines Corp. 2006               */
+/* COPYRIGHT International Business Machines Corp. 2006,2016              */
 /* All Rights Reserved                                                    */
 /*                                                                        */
 /* US Government Users Restricted Rights - Use, duplication or            */
 /* disclosure restricted by GSA ADP Schedule Contract with IBM Corp.      */
 /*                                                                        */
 /* IBM_PROLOG_END_TAG                                                     */
-static char sccsid[] = "@(#)99  1.2  src/ipfl/usr/lib/methods/cfg_ipf.c, ipflt, 53ipfl53H, 0624A_53ipfl53H 6/13/06 18:40:57";
+static char sccsid[] = "@(#)99  1.3  src/ipfl/usr/lib/methods/cfg_ipf.c, ipflt, 53ipfl53H, 1737A_53ipfl53H 11/2/16 02:33:08";
 /*
  * Copyright (C) 2005 by Darren Reed.
  *
@@ -284,6 +284,7 @@ queryipf(int major, int minor, dev_t devno)
 	struct cfg_load cfg;
 	int i;
 
+	bzero(&cfg, sizeof(cfg));
 	cfg.path = "/usr/lib/drivers/ipf";
 	cfg.kmid = 0;
 	if (sysconfig(SYS_QUERYLOAD, &cfg, sizeof(cfg)) == -1) {

--- a/usr/sbin/ippool_y.y
+++ b/usr/sbin/ippool_y.y
@@ -1,20 +1,20 @@
 /* IBM_PROLOG_BEGIN_TAG                                                   */
 /* This is an automatically generated prolog.                             */
 /*                                                                        */
-/* 53ipfl53H src/ipfl/usr/sbin/ippool_y.y 1.1                             */
+/* 53ipfl53H src/ipfl/usr/sbin/ippool_y.y 1.3                             */
 /*                                                                        */
 /* Licensed Materials - Property of IBM                                   */
 /*                                                                        */
 /* Restricted Materials of IBM                                            */
 /*                                                                        */
-/* (C) COPYRIGHT International Business Machines Corp. 2006               */
+/* COPYRIGHT International Business Machines Corp. 2006,2022              */
 /* All Rights Reserved                                                    */
 /*                                                                        */
 /* US Government Users Restricted Rights - Use, duplication or            */
 /* disclosure restricted by GSA ADP Schedule Contract with IBM Corp.      */
 /*                                                                        */
 /* IBM_PROLOG_END_TAG                                                     */
-/* @(#)72  1.2  src/ipfl/usr/sbin/ippool_y.y, ipflt, 53ipfl53H, 0619A_53ipfl53H 5/10/06 15:24:18 */
+/* @(#)72  1.3  src/ipfl/usr/sbin/ippool_y.y, ipflt, 53ipfl53H, 2226A_53ipfl53H 4/22/22 03:58:11 */
 %{
 #include <sys/types.h>
 #include <sys/time.h>
@@ -49,6 +49,13 @@
 #include "kmem.h"
 
 #define	YYDEBUG	1
+
+/* Increasing the YYMAXDEPTH (maximum size the stacks can grow) 
+ * to a higher value so that more IP entries in ippool table can be 
+ * accommodate */
+#ifndef YYMAXDEPTH
+#define YYMAXDEPTH 0x000fffff 
+#endif
 
 extern	int	yyparse __P((void));
 extern	int	yydebug;


### PR DESCRIPTION
This fixes following issues in AIX ip filter:

IV68985: ipmon64 may not act on signals
IV83473: IPFILTER 'PORT REDIRECTION' FUNCTIONALITY IS VERY SLOW/TIMES OUT
IV85810: SYSTEM CRASH AFTER IP FILTER UNCONFIGURATION
IJ47729: Fragmeneted packets are dropped by the ipf filter rule
IV83473: ipfilter port forwarding causes problem with largesend
IV89793: CFG_IPF -Q RESPONDS WITH "BAD ADDRESS"
IJ40988: yacc stack overflow error at '137'